### PR TITLE
Removed jcenter repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -32,7 +32,6 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
 }
 


### PR DESCRIPTION
jcenter is being turned off, so every project should migrate to an alternative, like mavenCentral